### PR TITLE
Add assembly entry point to interpret a function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ configure_file(
 
 enable_testing()
 
+enable_language(ASM_NASM)
+
 link_directories(/usr/local/lib)
 
 set(AB_COLOR_DIAGNOSTICS on CACHE BOOL "Enable/Disable colorized compiler output")
@@ -69,12 +71,12 @@ target_compile_options(ab-base
 		-Wall -Wextra
 )
 
-if(AB_COLOR_DIAGNOSTICS)
-	target_compile_options(ab-base
-		INTERFACE
-			-fdiagnostics-color=always
-	)
-endif()
+# if(AB_COLOR_DIAGNOSTICS)
+# 	target_compile_options(ab-base
+# 		INTERFACE
+# 			-fdiagnostics-color=always
+# 	)
+# endif()
 
 target_include_directories(ab-base
 	INTERFACE

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 ab_add_jinja_cxx_template(
 	INPUT  include/Ab/Wasm/OpCode.hpp.jinja
 	OUTPUT include/Ab/Wasm/OpCode.hpp
@@ -62,6 +61,7 @@ add_library(ab-core
 	include/Ab/Opcode.hpp
 	include/Ab/FuncBuilder.hpp
 	include/Ab/Interpreter.hpp
+	src/ab-core-Entry.nasm
 	src/ab-core-Interpreter.cpp
 	src/ab-core-Loading.cpp
 	src/ab-core-Process.cpp

--- a/core/include/Ab/Interpreter.hpp.jinja
+++ b/core/include/Ab/Interpreter.hpp.jinja
@@ -6,6 +6,7 @@
 #include <Ab/Assert.hpp>
 #include <Ab/Bytes.hpp>
 #include <Ab/Func.hpp>
+#include <Ab/State.hpp>
 
 namespace Ab {
 
@@ -98,65 +99,6 @@ struct NormalFrame {
 
 	FrameSaveArea save_area;
 	FrameTag tag;
-};
-
-/// Storage for saving machine registers at interpreter entry.
-/// NOTE: THIS CLASS IS WIP AND NOT USED
-///
-struct EntrySaveArea {
-	MutAddress sp;
-	MutAddress bp;
-};
-
-/// The current state of execution in the virtual machine.
-///
-/// This is a global property that can be asked of the VM. Under normal circumstances, the vm will
-/// be in the RUNNING state. When an uncaught exception or other error is triggered, the VM is
-/// brought down and enters the ERRORED state.
-///
-/// If the virtual machine hasn't been fully initialized, possibly due to a startup error, the vm
-/// will be in the UNDEFINED state.
-///
-/// After complete and successful execution of a program, the vm is placed into
-enum class ExecCond { UNDEFINED, RUNNING, HALTED, TRAPPED, ERRORED };
-
-enum class ExecAction { CRASH = 0, INTERPRET = 1, HALT = 2, EXIT = 3 };
-
-/// Flags are runtime conditions located in secondary state.
-///
-struct Flags {
-	bool trap;
-	bool error;
-};
-
-/// Primary state is cached in the interpreter, and kept in registers if possible.
-/// The state is only reflected back into the struct explicitly, when needed.
-///
-struct ExecStateA {
-	const Byte* ip;
-	Byte* sp;
-	FuncInst* fn;
-};
-
-/// Secondary state is kept in memory and up-to-date. Frequently accessed data
-/// should be placed in the primary state and cached in registers during execution.
-/// Infrequently accessed state can be stored here.
-///
-struct ExecStateB {
-	FuncInst* func;
-	Byte* stack;
-	ExecCond condition;
-	Flags flags;
-};
-
-/// Interpreter state is divided into primary and secondary state.
-/// primary state is frequently accessed, and typically cached in local registers.
-/// Secondary state is less frequently accessed, and normally kept up to date in memory.
-///
-struct ExecState {
-	ExecStateA st_a;  ///< primary execution state.
-	ExecStateB st_b;  ///< secondary execution state.
-	EntrySaveArea entry_save_area;
 };
 
 /// Blow away the execution state.

--- a/core/include/Ab/State.hpp
+++ b/core/include/Ab/State.hpp
@@ -1,0 +1,102 @@
+#ifndef AB_STATE_HPP_
+#define AB_STATE_HPP_
+
+#include <Ab/Config.hpp>
+#include <Ab/Address.hpp>
+#include <Ab/State.hpp>
+#include <cstddef>
+#include <type_traits>
+
+namespace Ab {
+
+/// Storage for saving machine registers at interpreter entry.
+/// NOTE: THIS CLASS IS WIP AND NOT USED
+///
+struct EntrySaveArea {
+	MutAddress sp;
+	MutAddress bp;
+};
+
+static_assert(std::is_standard_layout<EntrySaveArea>::value);
+static_assert(offsetof(EntrySaveArea, sp) == 0);
+static_assert(offsetof(EntrySaveArea, bp) == 8);
+static_assert(sizeof(EntrySaveArea) == 16);
+
+/// The current state of execution in the virtual machine.
+///
+/// This is a global property that can be asked of the VM. Under normal circumstances, the vm will
+/// be in the RUNNING state. When an uncaught exception or other error is triggered, the VM is
+/// brought down and enters the ERRORED state.
+///
+/// If the virtual machine hasn't been fully initialized, possibly due to a startup error, the vm
+/// will be in the UNDEFINED state.
+///
+/// After complete and successful execution of a program, the vm is placed into
+enum class ExecCond : uint8_t { UNDEFINED = 0, RUNNING, HALTED, TRAPPED, ERRORED };
+
+enum class ExecAction : uint8_t { CRASH = 0, INTERPRET, HALT, EXIT };
+
+/// Flags are runtime conditions located in secondary state.
+///
+struct Flags {
+	bool trap;
+	bool error;
+};
+
+static_assert(std::is_standard_layout<Flags>::value);
+static_assert(offsetof(Flags, trap) == 0);
+static_assert(offsetof(Flags, error) == 1);
+static_assert(sizeof(Flags) == 2);
+
+/// Primary state is cached in the interpreter, and kept in registers if possible.
+/// The state is only reflected back into the struct explicitly, when needed.
+///
+struct ExecStateA {
+	const Byte* ip;
+	Byte* sp;
+	FuncInst* fn;
+};
+
+static_assert(std::is_standard_layout<ExecStateA>::value);
+static_assert(offsetof(ExecStateA, ip) == 0);
+static_assert(offsetof(ExecStateA, sp) == 8);
+static_assert(offsetof(ExecStateA, fn) == 16);
+static_assert(sizeof(ExecStateA) == 24);
+
+/// Secondary state is kept in memory and up-to-date. Frequently accessed data
+/// should be placed in the primary state and cached in registers during execution.
+/// Infrequently accessed state can be stored here.
+///
+struct ExecStateB {
+	FuncInst* func;
+	Byte* stack;
+	ExecCond condition;
+	Flags flags;
+};
+
+static_assert(std::is_standard_layout<ExecStateB>::value);
+static_assert(offsetof(ExecStateB, func) == 0);
+static_assert(offsetof(ExecStateB, stack) == 8);
+static_assert(offsetof(ExecStateB, condition) == 16);
+static_assert(offsetof(ExecStateB, flags) == 17);
+static_assert(sizeof(ExecStateB) == 24);
+
+/// Interpreter state is divided into primary and secondary state.
+/// primary state is frequently accessed, and typically cached in local registers.
+/// Secondary state is less frequently accessed, and normally kept up to date in memory.
+///
+struct ExecState {
+	ExecStateA st_a;  ///< primary execution state.
+	ExecStateB st_b;  ///< secondary execution state.
+	EntrySaveArea entry_save_area;
+};
+
+static_assert(std::is_standard_layout<ExecState>::value);
+static_assert(offsetof(ExecState, st_a) == 0);
+static_assert(offsetof(ExecState, st_b) == 24);
+static_assert(offsetof(ExecState, entry_save_area) == 48);
+static_assert(sizeof(ExecState) == 64);
+
+}  // namespace Ab
+
+#endif  // AB_STATE_HPP_

--- a/core/include/Ab/State.nasm
+++ b/core/include/Ab/State.nasm
@@ -1,0 +1,21 @@
+%ifndef OMTALK_VMSTRUCTS_NASM_
+%define OMTALK_VMSTRUCTS_NASM_
+
+# EntrySaveArea
+struc EntrySaveArea
+    .sp: resq 1
+    .bp: resq 1
+endstruc
+
+%define ExecCond_UNDEFINED 0
+%define ExecCond_RUNNING 1
+%define ExecCond_HALTED 2
+%define ExecCond_TRAPPED 3
+%define ExecCond_ERRORED 4
+
+%define ExecAction_CRASH 0
+%define ExecAction_INTERPRET 1
+%define ExecAction_HALT 2
+%define ExecAction_EXIT 3
+
+%endif

--- a/core/include/Ab/VirtualMachine.hpp
+++ b/core/include/Ab/VirtualMachine.hpp
@@ -196,6 +196,8 @@ std::tuple<Rs...> static_call(Context& cx, ModuleInst* mod_inst, std::size_t ind
 	return static_call(cx, mod_inst->func_inst(index), as...);
 }
 
+extern "C" Byte* ab_act(ExecState* state, ExecAction action);
+
 }  // namespace Ab
 
 #endif  // AB_VIRTUALMACHINE_HPP_

--- a/core/src/ab-core-Entry.nasm
+++ b/core/src/ab-core-Entry.nasm
@@ -1,0 +1,11 @@
+%include "Ab/State.nasm"
+
+extern ab_act
+
+global ab_interpret_func
+
+section .text
+
+ab_interpret_func:
+    call ab_act
+    ret

--- a/core/src/ab-core-Interpreter.cpp.jinja
+++ b/core/src/ab-core-Interpreter.cpp.jinja
@@ -100,7 +100,9 @@ using ref = std::uint64_t;
 /// Forward Declarations
 ///
 
-static Byte* act(ExecState* state, ExecAction action);
+extern "C" Byte* ab_act(ExecState* state, ExecAction action);
+
+extern "C" Byte* ab_interpret_func(ExecState* state, ExecAction action);
 
 static std::pair<ExecAction, Byte*> do_interpret(ExecState* state);
 
@@ -339,7 +341,7 @@ static Byte* interpret_func(ExecState* state, FuncInst* func) {
 	state->st_b.func = func;
 	state->st_a.ip   = func->body();
 	state->st_a.fn   = nullptr;  // TODO: func->constants();
-	return act(state, ExecAction::INTERPRET);
+	return ab_interpret_func(state, ExecAction::INTERPRET);
 }
 
 static Byte* interpret_func(Context& cx, FuncInst* func) {
@@ -362,7 +364,7 @@ void interpret(ExecState* state, ModuleInst* mod, std::size_t index) {
 
 /// The main interpreter action trampoline.
 ///
-static Byte* act(ExecState* state, ExecAction action) {
+Byte* ab_act(ExecState* state, ExecAction action) {
 	constexpr static void* const ACTION_TABLE[4] = {
 		&&do_crash,      // 0
 		&&do_interpret,  // 1


### PR DESCRIPTION
This will be used to properly call into JIT'ed functions when available.